### PR TITLE
Fix for Issue #4: Improved Logic in remove for Modifying Index and Added display Function for Tree Visualization

### DIFF
--- a/bpt.h
+++ b/bpt.h
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>
+#include <iostream>
 
 #ifndef UNIT_TEST
 #include "predefined.h"
@@ -85,7 +86,7 @@ public:
     };
 
 #ifndef UNIT_TEST
-private:
+    public:
 #else
 public:
 #endif
@@ -107,7 +108,7 @@ public:
 
     /* remove internal node */
     void remove_from_index(off_t offset, internal_node_t &node,
-                           const key_t &key);
+                           const key_t &key, bool remove_flag = false);
 
     /* borrow one key from other internal node */
     bool borrow_key(bool from_right, internal_node_t &borrower,
@@ -232,6 +233,59 @@ public:
     }
 };
 
-}
+    class TreeStructureDisplay {
+    public:
+        TreeStructureDisplay(const bplus_tree &tree) : tree(tree) {}
 
+        void Display() {
+            displayNode(tree.get_meta().root_offset, 0);
+        }
+
+    private:
+        const bplus_tree &tree;
+
+        void displayNode(off_t offset, int level) {
+            if (offset == 0) {
+                return;
+            }
+
+            if (level < tree.get_meta().height) {
+                // 内部节点
+                internal_node_t node;
+                tree.map(&node, offset);
+
+                std::cout << indent(level) << "Internal Node at offset " << offset << ": contains " << node.n
+                          << " keys\n";
+                for (size_t i = 0; i < node.n; ++i) {
+                    std::cout << indent(level + 1) << "Key: " << node.children[i].key.k << ", Child: "
+                              << node.children[i].child << "\n";
+                }
+
+                // 递归遍历子节点
+                for (size_t i = 0; i < node.n; ++i) {
+                    displayNode(node.children[i].child, level + 1);
+                }
+            } else {
+                // 叶节点
+                leaf_node_t leaf;
+                tree.map(&leaf, offset);
+
+                std::cout << indent(level) << "Leaf Node at offset " << offset << ": contains " << leaf.n
+                          << " records\n";
+                for (size_t i = 0; i < leaf.n; ++i) {
+                    std::cout << indent(level + 1) << "Record: Key: " << leaf.children[i].key.k << ", Value: "
+                              << leaf.children[i].value << "\n";
+                }
+            }
+        }
+        //indent
+        std::string indent(int level) {
+            std::string res;
+            for (int i = 0; i < level; ++i) {
+                res += "  ";
+            }
+            return res;
+        }
+    };
+}
 #endif /* end of BPT_H */

--- a/util/unit_test.cc
+++ b/util/unit_test.cc
@@ -9,7 +9,14 @@
 #include "../bpt.h"
 using bpt::bplus_tree;
 
-int main(int argc, char *argv[])
+
+int test_complex();
+
+int main(int argc, char *argv[]){
+    test_complex();
+}
+
+int test_complex()
 {
     const int size = 128;
 
@@ -1120,6 +1127,41 @@ int main(int argc, char *argv[])
 
     PRINT("RemoveManyKeysReverse");
     }
+
+    {
+        bplus_tree tree("test.db", true);
+        assert(tree.meta.order == 4);
+        int sizeKeys = 10000;
+        char keys[sizeKeys][8];
+
+        // Create keys
+        for (int i = 0; i < sizeKeys; i++) {
+            sprintf(keys[i], "key%d", i);
+        }
+
+        // Insert keys
+        for (int i = 0; i < sizeKeys; i++) {
+            bpt::key_t k(keys[i]);
+            bpt::value_t v(i);
+            assert(tree.insert(k, v) == 0);
+        }
+
+        // Delete keys in reverse order
+        for (int i = sizeKeys - 1; i >= 0; i--) {
+            bpt::key_t k(keys[i]);
+            assert(tree.remove(k) == 0);
+        }
+
+        // Check if keys are removed
+        for (int i = 0; i < sizeKeys; i++) {
+            bpt::key_t k(keys[i]);
+            bpt::value_t v;
+            assert(tree.search(k, &v) != 0);
+        }
+
+        PRINT("RemoveLargeKeysReverse");
+    }
+
 
     unlink("test.db");
 


### PR DESCRIPTION
This Pull Request addresses the bug described in Issue #4, related to an error encountered in the B+ Tree deletion operation. The following changes have been made:

1. **Improved Logic in `remove` Function**: 
   - The logic within the `remove` function, which is responsible for modifying the index during deletion operations, has been enhanced. This improvement specifically addresses the bug encountered when deleting certain keys in sequence (as described in Issue #4). The updated logic ensures more robust handling of edge cases, preventing errors during the deletion process.

2. **Added `display` Function for Tree Visualization**:
   - To aid in better understanding and debugging of the B+ Tree structure, a new `display` function has been implemented. This function allows for a visual representation of the entire tree, making it easier to track changes and verify the integrity of the tree structure after operations like insertions and deletions.

These changes aim to enhance the functionality and reliability of the B+ Tree implementation, making it more user-friendly and easier to debug. The `display` function, in particular, provides valuable insights into the tree structure, which is crucial for both developers and users working with this data structure.

Looking forward to the feedback and hoping for a positive review for merging these improvements into the main branch.
